### PR TITLE
add options: apt_repository_codename and unprivileged_container

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,8 @@
 ---
+######### install options
+apt_repository_codename: '' # allow debian based distros to use packages from different version, e.g. ubuntu impish can use hirsute packages
+unprivileged_container: false # setting to true skips 'disable-transparent-huge-pages' service which won't work on unprivileged containers (e.g. on LCX)
+
 ######### redis config
 redis_cluster_replica: 1
 redis_cluster_conf:

--- a/tasks/redis-cluster-install-Debian.yml
+++ b/tasks/redis-cluster-install-Debian.yml
@@ -18,7 +18,7 @@
     - name: redis-cluster-install | Add Redis source repository into sources list
       ansible.builtin.apt_repository:
         repo: ppa:redislabs/redis
-        codename: '{{apt_repository_codename}}'
+        codename: '{{ apt_repository_codename }}'
         filename: /etc/apt/sources.list.d/redis.list
         state: present
         update_cache: true

--- a/tasks/redis-cluster-install-Debian.yml
+++ b/tasks/redis-cluster-install-Debian.yml
@@ -18,6 +18,7 @@
     - name: redis-cluster-install | Add Redis source repository into sources list
       ansible.builtin.apt_repository:
         repo: ppa:redislabs/redis
+        codename: '{{apt_repository_codename}}'
         filename: /etc/apt/sources.list.d/redis.list
         state: present
         update_cache: true

--- a/tasks/redis-cluster-operating-system-tweaks.yml
+++ b/tasks/redis-cluster-operating-system-tweaks.yml
@@ -33,3 +33,4 @@
     enabled: True
     state: started
   changed_when: false
+  when: unprivileged_container == false 


### PR DESCRIPTION
Two scenarios covered by additional variables:

1. `apt_repository_codename` - allow Debian based distros to use packages from different version, e.g. Ubuntu Impish can use Hirsute packages as Impish does not have its releases in official ppa
2. `unprivileged_container` - setting to true skips 'disable-transparent-huge-pages' service, which won't work on unprivileged containers (e.g. on LXC)