### PR TITLE
Requirepass fixes

### DIFF
--- a/templates/etc/redis/redis.conf.j2
+++ b/templates/etc/redis/redis.conf.j2
@@ -86,6 +86,9 @@ cluster-migration-barrier {{ redis_cluster_conf.cluster_migration_barrier | defa
 cluster-require-full-coverage {{ redis_cluster_conf.cluster_require_full_coverage | default('no') }}
 cluster-allow-reads-when-down {{ redis_cluster_conf.cluster_allow_reads_when_down | default('yes') }}
 repl-ping-slave-period {{ redis_cluster_conf.repl_ping_slave_period | default('2') }}
+{% if redis_cluster_conf.requirepass is defined and redis_role == "slave" %}
+masterauth {{ redis_cluster_conf.requirepass }}
+{% endif %}
 {% endif %}
 
 

--- a/templates/systemd/redis-exporter.service.j2
+++ b/templates/systemd/redis-exporter.service.j2
@@ -10,9 +10,15 @@ User=redis
 Group=redis
 Type=simple
 {% if redis_role is defined and redis_role == "master" %}
-ExecStart=/usr/local/bin/redis_exporter -redis.addr redis://127.0.0.1:{{ redis_cluster_conf.master_port | default('6379') }}
+{% set redis_use_port = redis_cluster_conf.master_port | default('6379') %}
 {% else %}
-ExecStart=/usr/local/bin/redis_exporter -redis.addr redis://127.0.0.1:{{ redis_cluster_conf.slave_port | default('6379') }}
+{% set redis_use_port = redis_cluster_conf.slave_port | default('6379') %}
 {% endif %}
+{% if redis_cluster_conf.requirepass is defined %}
+{% set redis_password_val = ' -redis.password ' ~ redis_cluster_conf.requirepass %}
+{% else %}
+{% set redis_password_val = '' %}
+{% endif %}
+ExecStart=/usr/local/bin/redis_exporter -redis.addr redis://127.0.0.1:{{ redis_use_port }}{{ redis_password_val }}
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
When requirepass is defined there are a couple of issues with the resulting cluster:
1. The replica nodes cannot connect to the master nodes for replication
2. The redis-exporter service cannot gather metrics from the nodes

In both cases the problem is that the password is not made available. This PR aims to address that